### PR TITLE
Make sure we use MaxRetries correctly

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -391,7 +391,7 @@ func applyFn(ctx context.Context) error {
 
 	o.Output("Starting initial Chef-Client run...")
 
-	for attempt := 0; attempt < p.MaxRetries; attempt++ {
+	for attempt := 0; attempt <= p.MaxRetries; attempt++ {
 		// Make sure to (re)connect before trying to run Chef-Client.
 		if err := communicator.Retry(retryCtx, func() error {
 			return comm.Connect(o)
@@ -423,7 +423,11 @@ func applyFn(ctx context.Context) error {
 			err = nil
 		}
 
-		if p.RetryOnExitCode[exitError.ExitStatus] {
+		if !p.RetryOnExitCode[exitError.ExitStatus] {
+			return err
+		}
+
+		if attempt < p.MaxRetries {
 			o.Output(fmt.Sprintf("Waiting %s before retrying Chef-Client run...", p.WaitForRetry))
 			time.Sleep(p.WaitForRetry)
 		}

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -52,9 +52,8 @@ func New(s *terraform.InstanceState) (*Communicator, error) {
 
 // Connect implementation of communicator.Communicator interface
 func (c *Communicator) Connect(o terraform.UIOutput) error {
-	if c.client != nil {
-		return nil
-	}
+	// Set the client to nil since we'll (re)create it
+	c.client = nil
 
 	params := winrm.DefaultParameters
 	params.Timeout = formatDuration(c.Timeout())

--- a/website/docs/provisioners/chef.html.markdown
+++ b/website/docs/provisioners/chef.html.markdown
@@ -112,7 +112,7 @@ The following arguments are supported:
 * `https_proxy (string)` - (Optional) The proxy server for Chef Client HTTPS connections.
 
 * `max_retries (integer)` - (Optional) The number of times to retry the provisioning process
-  after receiving an exit code in the `retry_on_error` list. Defaults to `1`
+  after receiving an exit code in the `retry_on_error` list. Defaults to `0`
 
 * `named_run_list (string)` - (Optional) The name of an alternate run-list to invoke during the
   initial Chef Client run. The run-list must already exist in the Policyfile that defines
@@ -136,9 +136,10 @@ The following arguments are supported:
 * `recreate_client (boolean)` - (Optional) If `true`, first delete any existing Chef Node and
   Client before registering the new Chef Client.
 
-* `retry_on_error (list of integers)` - (Optional) The error codes upon which Terraform should
+* `retry_on_error (array)` - (Optional) The error codes upon which Terraform should
   gracefully retry the provisioning process. Intended for use with
   [Chef RFC062 codes](https://github.com/chef-boneyard/chef-rfc/blob/master/rfc062-exit-status.md).
+  (Defaults to `[35, 37, 213]`)
 
 * `run_list (array)` - (Optional) A list with recipes that will be invoked during the initial
   Chef Client run. The run-list will also be saved to the Chef Server after a successful


### PR DESCRIPTION
Even if MaxRetries is 0, we should still execute the loop one time in order to run the Chef-Client at least once. Also waiting only makes sense when we have `attempts` left. And last but not least we want to exit immediately when the exit code is not in the retry list.

It seems like a good idea to tweak the defaults a little as well. By making the defaults _not_ do any retries and set the retry on exit codes to 35, 37 and 213 it seems to be a bit less impacting. It would mean no changes by default except for the fact a reboot exit code no longer generates a failed apply. And if you do want to retry, you only have to set the max retries to a positive number.