### PR TITLE
Remove (now) incorrect example

### DIFF
--- a/website/docs/provisioners/chef.html.markdown
+++ b/website/docs/provisioners/chef.html.markdown
@@ -60,8 +60,6 @@ resource "aws_instance" "web" {
     version         = "15.10.13"
     # If you have a self signed cert on your chef server change this to :verify_none
     ssl_verify_mode = ":verify_peer"
-    # Gracefully handle Chef upgrades, reboots, etc.
-    retry_on_exit_code = [35, 213]
   }
 }
 ```


### PR DESCRIPTION
This example doesn't really show how these values should be used. The
default of retry_on_exit_code is now already when most people want, so
this line is not needed in most cases.

I think the docs describe the new options just fine, so lets leave this
out...